### PR TITLE
update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # 開発サーバ起動
 
-    npm run serve
+    npm start
 
 `localhost:3100` に開発用ローカルサイトが立ち上がります。
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "index.js",
   "scripts": {
     "test": "bulbo build",
+    "start": "npm run serve",
     "serve": "bulbo serve",
     "build": "cross-env BASEPATH=http://nodejs.jp bulbo build"
   },

--- a/source/docs.md
+++ b/source/docs.md
@@ -5,13 +5,11 @@
 ## 公式ドキュメント
 
 - [Node.js 最新](https://nodejs.org/api/)
-- [Node.js v4.x](https://nodejs.org/dist/latest-v4.x/docs/api/)
 - [Node.js v6.x](https://nodejs.org/dist/latest-v6.x/docs/api/)
+- [Node.js v4.x](https://nodejs.org/dist/latest-v4.x/docs/api/)
 
 ## Node.js 関連
 
-- [Node.js ハンズオン](http://dl.dropbox.com/u/219436/node.js/handson/build/html/index.html) by [@yssk22](http://twitter.com/yssk22)
-  - Node.js の基本から Web アプリケーションの作り方まで、ハンズオン形式で解説しています。
 - [Node.js ハンズオン](http://d.hatena.ne.jp/t_43z/20101021/1287655787) by [@meso](http://twitter.com/meso)
   - Node.js のインストールから WebSocket を使った簡単なサンプルが動かせるところまでを解説しています。
 - [Node.js とは何か (1)](http://d.hatena.ne.jp/badatmath/20101020/1287587240), [(2)](http://d.hatena.ne.jp/badatmath/20101022/1287701281), [(3)](http://d.hatena.ne.jp/badatmath/20101026/1288109275), [(4)](http://d.hatena.ne.jp/badatmath/20101101/1288644245) by [@bad_at_math](http://twitter.com/bad_at_math)
@@ -31,13 +29,17 @@
 - [Stream ハンドブック](https://github.com/meso/stream-handbook) by substack translated by meso
   - [stream-handbook](https://github.com/substack/stream-handbook) の日本語訳です。Node.js の Stream API の入門書です。
 
-## 関連ドキュメント
+## ワークショップ(オンラインコース)
 
-- [npm デベロッパーズガイド 日本語訳](http://hideyukisaito.com/doc/npm/dev/)
-  - [npm Developers Guide](https://github.com/isaacs/npm/blob/master/doc/developers.md) の日本語訳です。
-- [Express 日本語ドキュメンテーション](http://hideyukisaito.github.com/expressjs-doc_ja/)
-  - Web フレームワーク [Express](http://expressjs.com/) のドキュメントの日本語訳です。
-- [Railway 日本語訳](http://railwayjs.jp/)
-  - Express 上で動作する MVC フレームワーク [Railway](http://railwayjs.com/) のドキュメントの日本語訳です。
-- [Mongoose - デベロッパーズガイド 日本語訳](http://muddy-dixon.appspot.com/ja/mongoosejs/index.html)
-  - MongoDB に対する ORM-like な機能を提供するユーティリティライブラリ [Mongoose](https://github.com/LearnBoost/mongoose) のドキュメントの日本語訳です。
+- [NodeSchool](https://nodeschool.io/ja/index.html)
+  - コマンドライン形式の対話型学習ツールです。Node.js や関連フレームワークについてのコースが豊富にあります。
+  - 以下はその一例です。
+  - [learnyounode](https://github.com/workshopper/learnyounode)
+    - Node.js ワークショップ
+    - `npm i -g learnyounode ; learnyounode` で実行出来ます。
+  - [How to npm](https://github.com/workshopper/how-to-npm)
+    - npm入門ワークショップ
+    - `npm i -g how-to-npm ; how-to-npm` で実行出来ます。
+  - [elementary-electron](https://github.com/maxogden/elementary-electron)
+    - エレクトロン入門ワークショップ
+    - `npm i -g elementary-electron ; elementary-electron` で実行出来ます。


### PR DESCRIPTION
- デッドリンクを削除
- NodeSchool へのリンクを追加
- npm start コマンドを追加


---
- Node.js ハンズオン は dropbox の仕様変更の影響でページとして見れなくなっている為削除しました
- npm / express / mongoose は日本語ドキュメントがアクセスできなくなっているので削除しました
- railwayjs は本家が rename されていますが、フォローされていないようなので削除しました。

---
close #219 