### PR TITLE
Fix a style of images that is protruding from the screen

### DIFF
--- a/source/css/style.css
+++ b/source/css/style.css
@@ -9,3 +9,7 @@ a {
 .title {
   line-height: 1.5;
 }
+
+img {
+  max-width: 100%;
+}


### PR DESCRIPTION
* Add `max-width: 100%` to img tag in css

Fixes: #214