### PR TITLE
master (GH pages) のアップデート時に circle ci のビルドを走らせない修正

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -5,5 +5,5 @@ git clone -b master https://github.com/nodejsjp/nodejsjp.github.com.git build
 npm run build
 cd build
 git add .
-git commit -m 'chore(site): update build'
+git commit -m 'chore(site): update build [skip ci]'
 git push origin HEAD


### PR DESCRIPTION
master (GH pages) は静的コンテンツしか入っていないので、ビルドしようとすると失敗するので、ビルド自体をスキップするようにする設定です。 ( circle ci はコミットコメントに [skip ci] と書くとビルドをスキップしてくれます https://circleci.com/docs/1.0/skip-a-build/ )