### PR TITLE
watch 中の event ファイル変更などでエラー終了するバグを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "layout-wrapper": "^1.1.1",
     "nunjucks": "^3.0.0",
     "nunjucks-date": "^1.2.0",
-    "vinyl-accumulate": "^1.3.2"
+    "vinyl-accumulate": "^1.4.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2176,9 +2176,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-vinyl-accumulate@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/vinyl-accumulate/-/vinyl-accumulate-1.3.2.tgz#5c49d7b7566aa6e99ac62c2799d8e95f6a8f1f6a"
+vinyl-accumulate@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/vinyl-accumulate/-/vinyl-accumulate-1.4.1.tgz#2b22679df61a3543e973f7b6fa3e9f745d4fdaba"
   dependencies:
     debounce "^1.0.0"
     duplexer2 "^0.1.4"


### PR DESCRIPTION
vinyl-accumulate 内で transform の callback を 2回呼んでしまう箇所があって、 その原因で、watch 中に event ファイルなどを修正すると落ちる状態になっていました。
vinyl-accumulate 最新版では修正されているようなので、最新版にあげる修正です。
(修正が入った当該コミット https://github.com/kt3k/vinyl-accumulate/commit/24a57b5bda04e6941891a53c9ea706905dd8a339 )

---
close #228 