### PR TITLE
[News][更新] node8 記事

### DIFF
--- a/source/news/2017/05-31-node8.md
+++ b/source/news/2017/05-31-node8.md
@@ -6,13 +6,10 @@ author: kt3k
 
 Node v8.0.0 がリリースされました。
 
-- 公式アナウンス
-  - https://nodejs.org/en/blog/release/v8.0.0/
-- Node8の注目的変更まとめ by hiroppy さん
-  - http://abouthiroppy.hatenablog.jp/entry/2017/05/30/090015
-- hiroppy さんの node 8 解説スライド
-  - https://abouthiroppy.github.io/slides/node8/
-
+- [公式アナウンス](https://nodejs.org/en/blog/release/v8.0.0/)
+- [Node v8.0 がリリースされた](http://yosuke-furukawa.hatenablog.com/entry/2017/06/06/092527) by [@yosuke-furukawa](https://github.com/yosuke-furukawa)
+- [Node8の注目的変更まとめ](http://abouthiroppy.hatenablog.jp/entry/2017/05/30/090015) by [@abouthiroppy](https://github.com/abouthiroppy)
+- [NODE@8.0.0 (スライド)](https://abouthiroppy.github.io/slides/node8/) by [@abouthiroppy](https://github.com/abouthiroppy)
 
 node の最新版について議論/質問したい方は slack に参加しましょう!
-- slack 参加はこちらから https://iojs-jp-slack.herokuapp.com
+- slack 参加は[こちら](https://iojs-jp-slack.herokuapp.com)から


### PR DESCRIPTION
- 会長の記事を追加
- 人のメンションの仕方を微妙に調整 (さん、を付けたり付けなかったりしているときりがないので、github のアカウントのメンションぽい体裁にしてみました。)

---

<img width="958" alt="2017-06-06 11 05 26" src="https://cloud.githubusercontent.com/assets/613956/26810769/77e746b0-4aa8-11e7-8141-f71cc4ed393e.png">
