### PR TITLE
[https化対応] サイトのルートへの参照を相対 path に変更

### DIFF
--- a/bulbofile.js
+++ b/bulbofile.js
@@ -12,7 +12,8 @@ const data = {
   orgName: 'Node.js 日本ユーザーグループ',
   pages: require('./pages'),
   layoutDir: path.join(__dirname, 'source/layout'),
-  basepath: process.env.BASEPATH || ''
+  // file を受け取って root への相対パスを返す関数
+  basepath: file => path.dirname(path.relative(file.relative, ''))
 }
 
 require('nunjucks').configure().addFilter('date', require('nunjucks-date'))

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "homepage": "http://nodejs.jp",
   "main": "index.js",
   "scripts": {
-    "test": "bulbo build",
+    "test": "npm run build",
     "start": "npm run serve",
     "serve": "bulbo serve",
-    "build": "cross-env BASEPATH=http://nodejs.jp bulbo build"
+    "build": "bulbo build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "bulbo": "^6.13.0",
-    "cross-env": "^3.1.3",
     "gulp-front-matter": "^1.3.0",
     "gulp-marked": "^1.0.0",
     "gulp-nunjucks": "^2.3.0",

--- a/source/layout/event-index.njk
+++ b/source/layout/event-index.njk
@@ -5,7 +5,7 @@
 
   {% for event in file.files %}
     <hr />
-    <h2><a href="{{ basepath }}/{{ event.relative }}">{{ event.fm.name }}</a></h2>
+    <h2><a href="{{ basepath(file) }}/{{ event.relative }}">{{ event.fm.name }}</a></h2>
     <p>日時:
     {% for date in event.fm.date %}
       {% if not loop.first %}
@@ -14,7 +14,7 @@
       {{ date | date('YYYY年MM月DD日') }}
     {% endfor %}
     {% if event.fm.image %}
-      <p><a href="{{ basepath }}{{ event.relative }}"><img src="{{ event.fm.image }}" /></a></p>
+      <p><a href="{{ basepath(file) }}{{ event.relative }}"><img src="{{ event.fm.image }}" /></a></p>
     {% endif %}
     </ul>
   {% endfor %}

--- a/source/layout/event.njk
+++ b/source/layout/event.njk
@@ -5,9 +5,9 @@
   <hr />
   {% if file.fm.image %}
     {% if file.fm.site %}
-      <a href="{{ file.fm.site.url }}"><img src="{{ basepath }}/{{ file.fm.image }}" /></a>
+      <a href="{{ file.fm.site.url }}"><img src="{{ basepath(file) }}/{{ file.fm.image }}" /></a>
     {% else %}
-      <img src="{{ basepath }}/{{ file.fm.image }}" />
+      <img src="{{ basepath(file) }}/{{ file.fm.image }}" />
     {% endif %}
     <br/>
     <br/>

--- a/source/layout/job.njk
+++ b/source/layout/job.njk
@@ -4,7 +4,7 @@
 <h1>{{ file.fm.name }}</h1>
 {% if file.fm.image %}
   <a href="{{ file.fm.url }}">
-    <img src="{{ basepath }}/{{ file.fm.image }}" width="165" style="margin: 15px;"/>
+    <img src="{{ basepath(file) }}/{{ file.fm.image }}" width="165" style="margin: 15px;"/>
   </a>
 {% endif %}
 {% if file.fm.role %}

--- a/source/layout/jobboard.njk
+++ b/source/layout/jobboard.njk
@@ -5,9 +5,9 @@
 
 {% for file in file.files %}
 <hr />
-<h2><a href="{{ basepath }}/{{ file.relative }}">{{ file.fm.name }}</a></h2>
+<h2><a href="{{ basepath(file) }}/{{ file.relative }}">{{ file.fm.name }}</a></h2>
 {% if file.fm.image %}
-  <p><img src="{{ basepath }}/{{ file.fm.image }}" width="120" style="margin: 15px;"></p>
+  <p><img src="{{ basepath(file) }}/{{ file.fm.image }}" width="120" style="margin: 15px;"></p>
 {% endif %}
 <p>
 {% if file.fm.role %}

--- a/source/layout/layout.njk
+++ b/source/layout/layout.njk
@@ -1,19 +1,19 @@
 <title>{{ orgName }}</title>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="{{ basepath }}/css/tacit.min.css"/>
-<link rel="stylesheet" href="{{ basepath }}/css/style.css"/>
-<link rel="icon" href="{{ basepath }}/images/favicon.png" />
+<link rel="stylesheet" href="{{ basepath(file) }}/css/tacit.min.css"/>
+<link rel="stylesheet" href="{{ basepath(file) }}/css/style.css"/>
+<link rel="icon" href="{{ basepath(file) }}/images/favicon.png" />
 
 <nav>
-<img width="150" src="{{ basepath }}/images/nodejs-logo.svg" />
+<img width="150" src="{{ basepath(file) }}/images/nodejs-logo.svg" />
 <br />
 <ul>
 {% for page in pages %}
   {% if page.path == file.relative %}
     <li>{{ page.name }}
   {% else %}
-    <li><a href="{{ basepath }}/{{ page.path }}">{{ page.name }}</a>
+    <li><a href="{{ basepath(file) }}/{{ page.path }}">{{ page.name }}</a>
   {% endif %}
 {% endfor %}
 </ul>

--- a/source/layout/news-index.njk
+++ b/source/layout/news-index.njk
@@ -7,7 +7,7 @@
 <hr />
 <h2>
   <small>{{ file.fm.date | date('YYYY/MM/DD') }}</small>
-  <a href="{{ basepath }}/{{ file.relative }}">{{ file.fm.title }}</a>
+  <a href="{{ basepath(file) }}/{{ file.relative }}">{{ file.fm.title }}</a>
 </h2>
 {% endfor %}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,9 +185,9 @@ builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
-bulbo@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/bulbo/-/bulbo-6.9.0.tgz#d268402f6f97e3813a8c2d8f99ad489fd5b2a2d3"
+bulbo@^6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/bulbo/-/bulbo-6.13.0.tgz#48773521a42af4e22baba96f61b5ec405375810d"
   dependencies:
     chalk "^1.1.1"
     chokidar "^1.4.2"
@@ -198,7 +198,7 @@ bulbo@^6.9.0:
     minirocket "^2.0.0"
     stream-splicer "^2.0.0"
     vinyl-fs "^2.2.1"
-    vinyl-serve "^2.7.0"
+    vinyl-serve "^2.8.0"
 
 callsite@^1.0.0:
   version "1.0.0"
@@ -331,19 +331,6 @@ convert-source-map@^1.1.1:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-
-cross-env:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-3.1.3.tgz#58cd8231808f50089708b091f7dd37275a8e8154"
-  dependencies:
-    cross-spawn "^3.0.1"
-
-cross-spawn@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
-  dependencies:
-    lru-cache "^4.0.1"
-    which "^1.2.9"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -1407,13 +1394,6 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
-lru-cache@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.1.tgz#1343955edaf2e37d9b9e7ee7241e27c4b9fb72be"
-  dependencies:
-    pseudomap "^1.0.1"
-    yallist "^2.0.0"
-
 map-cache@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
@@ -1753,10 +1733,6 @@ preserve@^0.2.0:
 process-nextick-args@^1.0.6, process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
-
-pseudomap@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 qs@~6.2.0:
   version "6.2.1"
@@ -2213,9 +2189,9 @@ vinyl-fs@^2.2.1, vinyl-fs@^2.4.4:
     vali-date "^1.0.0"
     vinyl "^1.0.0"
 
-vinyl-serve@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/vinyl-serve/-/vinyl-serve-2.7.0.tgz#ae1fef3ffb32264a1ba738c0abf4219b850c367f"
+vinyl-serve@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/vinyl-serve/-/vinyl-serve-2.8.0.tgz#c92af74dfccb43e1274d3786fcbe20c9354cda49"
   dependencies:
     es6-promise "^4.0.3"
     mime "^1.3.4"
@@ -2256,7 +2232,7 @@ vinyl@^2.0.0:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
-which@^1.2.10, which@^1.2.9:
+which@^1.2.10:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.11.tgz#c8b2eeea6b8c1659fa7c1dd4fdaabe9533dc5e8b"
   dependencies:
@@ -2293,10 +2269,6 @@ xtend@~3.0.0:
 y18n@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-
-yallist@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.0.0.tgz#306c543835f09ee1a4cb23b7bce9ab341c91cdd4"
 
 yargs@^3.32.0:
   version "3.32.0"


### PR DESCRIPTION
- `basepath` テンプレ変数を固定の文字列 (`http://nodejs.jp` など) から、関数に変更
- basepath 関数で、レンダリングしようとしてるページの path からサイトの root への path を相対 path で算出するように変更しました。

上の変更でホスト名が html 内にハードコードされなくなり、相対 path 参照になるため、 `http://nodejs.jp` で動いても `https://nodejs.jp` で動いても、それぞれ同 protocol 内で閉じて閲覧できるようになったはずです。