### PR TITLE
refactor: use branch-pipe

### DIFF
--- a/bulbofile.js
+++ b/bulbofile.js
@@ -7,6 +7,7 @@ const nunjucks = require('gulp-nunjucks')
 const marked = require('gulp-marked')
 const wrapper = require('layout-wrapper')
 const accumulate = require('vinyl-accumulate')
+const branch = require('branch-pipe')
 
 const data = {
   orgName: 'Node.js 日本ユーザーグループ',
@@ -49,59 +50,53 @@ asset('source/events/**/*.md')
   }))
   .pipe(layout('index'))
 
-// Event index pages
+// Event pages
 asset('source/events/**/*.md')
   .watch('source/**/*.{md,njk}')
   .pipe(frontMatter({property: 'fm'}))
   .pipe(marked())
-  .pipe(accumulate('events.html', {
-    debounce: true,
-    sort: (x, y) => y.fm.date[0].valueOf() - x.fm.date[0].valueOf()
-  }))
-  .pipe(layout('event-index'))
+  .pipe(branch.obj(src => [
+    src
+      .pipe(accumulate('events.html', {
+        debounce: true,
+        sort: (x, y) => y.fm.date[0].valueOf() - x.fm.date[0].valueOf()
+      }))
+      .pipe(layout('event-index')), // Event index page
+    src
+      .pipe(layout('event')) // Single event page
+  ]))
 
-// Single event page
-asset('source/events/**/*.md')
-  .watch('source/**/*.{md,njk}')
-  .pipe(frontMatter({property: 'fm'}))
-  .pipe(marked())
-  .pipe(layout('event'))
-
-// News index page
+// News pages
 asset('source/news/**/*.md')
   .watch('source/**/*.{md,njk}')
   .pipe(frontMatter({property: 'fm'}))
   .pipe(marked())
-  .pipe(accumulate('news.html', {
-    debounce: true,
-    sort: (x, y) => y.fm.date.valueOf() - x.fm.date.valueOf()
-  }))
-  .pipe(layout('news-index'))
+  .pipe(branch.obj(src => [
+    src
+      .pipe(accumulate('news.html', {
+        debounce: true,
+        sort: (x, y) => y.fm.date.valueOf() - x.fm.date.valueOf()
+      }))
+      .pipe(layout('news-index')), // News index page
+    src
+      .pipe(layout('news')) // Single news page
+  ]))
 
-// Single news pages
-asset('source/news/**/*.md')
-  .watch('source/**/*.{md,njk}')
-  .pipe(frontMatter({property: 'fm'}))
-  .pipe(marked())
-  .pipe(layout('news'))
-
-// Job index page
+// Jobboard pages
 asset('source/jobs/**/*.md')
   .watch('source/**/*.{md,njk}')
   .pipe(frontMatter({property: 'fm'}))
   .pipe(marked())
-  .pipe(accumulate('jobboard.html', {
-    debounce: true,
-    sort: (x, y) => y.fm.postedAt.valueOf() - x.fm.postedAt.valueOf()
-  }))
-  .pipe(layout('jobboard'))
-
-// Single job page
-asset('source/jobs/**/*.md')
-  .watch('source/**/*.{md,njk}')
-  .pipe(frontMatter({property: 'fm'}))
-  .pipe(marked())
-  .pipe(layout('job'))
+  .pipe(branch.obj(src => [
+    src
+      .pipe(accumulate('jobboard.html', {
+        debounce: true,
+        sort: (x, y) => y.fm.postedAt.valueOf() - x.fm.postedAt.valueOf()
+      }))
+      .pipe(layout('jobboard')), // Job index page
+    src
+      .pipe(layout('job')) // Single job page
+  ]))
 
 asset('source/css/*.css')
 asset('source/images/**/*.{png,svg,jpg,jpeg,gif}')

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "vinyl-accumulate": "^1.4.1"
   },
   "devDependencies": {
+    "branch-pipe": "^1.0.1",
     "rimraf": "^2.5.4"
   }
 }

--- a/source/layout/event-index.njk
+++ b/source/layout/event-index.njk
@@ -14,7 +14,7 @@
       {{ date | date('YYYY年MM月DD日') }}
     {% endfor %}
     {% if event.fm.image %}
-      <p><a href="{{ basepath(file) }}{{ event.relative }}"><img src="{{ event.fm.image }}" /></a></p>
+      <p><a href="{{ basepath(file) }}/{{ event.relative }}"><img src="{{ event.fm.image }}" /></a></p>
     {% endif %}
     </ul>
   {% endfor %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -167,6 +167,13 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+branch-pipe@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/branch-pipe/-/branch-pipe-1.0.1.tgz#f1a1903d15cf8421658ead586c062db7c8dc253d"
+  dependencies:
+    duplexer2 "^0.1.4"
+    merge-stream "^1.0.1"
+
 buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
@@ -1424,6 +1431,12 @@ meow@^3.3.0:
 merge-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.0.tgz#9cfd156fef35421e2b5403ce11dc6eb1962b026e"
+  dependencies:
+    readable-stream "^2.0.1"
+
+merge-stream@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
   dependencies:
     readable-stream "^2.0.1"
 


### PR DESCRIPTION
- branch-pipe というユーティリティを使って、source が同じ asset のビルドをそれぞれ1つにまとめました (news と news-index, job と job-index, event と event-index など)
- イベント一覧ページでイベント画像のリンク先 URL が正しくなかったので修正しました