### PR TITLE
slack 導線

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # [nodejs.jp][homepage]
 
+[![](https://img.shields.io/badge/SLACK-JOIN_CHAT_%E2%86%92-551a8b.svg?style=flat-square)](https://iojs-jp-slack.herokuapp.com/)
+
 # インストール
 ```sh
 $ yarn install

--- a/source/layout/index.njk
+++ b/source/layout/index.njk
@@ -15,6 +15,11 @@
   <li><a href="https://nodejs.org/dist/latest-v6.x/docs/api/">Node.js v6.x</a>
 </ul>
 
+<h2>Slack</h2>
+
+<a href="https://iojs-jp-slack.herokuapp.com/">Slack 参加はこちらから</a>
+
+
 {% for eventFile in file.files %}
   {% if loop.first %}
     <h2>イベント情報</h2>

--- a/source/layout/layout.njk
+++ b/source/layout/layout.njk
@@ -38,6 +38,7 @@
           <ul>
             <li><small><a target="_blank" href="https://github.com/nodejsjp/nodejsjp.github.com">GitHub</a></small></li>
             <li><small><a target="_blank" href="https://twitter.com/nodejsjp">Twitter</a></small></li>
+            <li><small><a target="_blank" href="https://iojs-jp-slack.herokuapp.com/">Slack</a></small></li>
           </ul>
         </nav>
       </article>


### PR DESCRIPTION
Slack の入口がわかりにくいという feedback があるため、slack 登録導線を増やす変更です

以下の箇所に slack への導線を追加しています。
- トップページ
- フッター
- github の README

close #249 

---
![localhost-3100-index html ipad](https://user-images.githubusercontent.com/613956/32403343-b15b8250-c17a-11e7-81e5-c9685aa6c153.png)
