### PR TITLE
gulp-marked は obsolete & 脆弱なので、 gulp-markdown に移行

### DIFF
--- a/bulbofile.js
+++ b/bulbofile.js
@@ -4,7 +4,7 @@ const asset = bulbo.asset
 const path = require('path')
 const frontMatter = require('gulp-front-matter')
 const nunjucks = require('gulp-nunjucks')
-const marked = require('gulp-marked')
+const markdown = require('gulp-markdown')
 const wrapper = require('layout-wrapper')
 const accumulate = require('vinyl-accumulate')
 const branch = require('branch-pipe')
@@ -36,14 +36,14 @@ asset('source/**/*.md', '!source/{events,jobs,news}/**/*')
   .watch('source/**/*.{md,njk}')
   .pipe(frontMatter({property: 'fm'}))
   .pipe(nunjucks.compile(data))
-  .pipe(marked())
+  .pipe(markdown())
   .pipe(layout('default'))
 
 // Index page
 asset('source/events/**/*.md')
   .watch('source/**/*.{md,njk}')
   .pipe(frontMatter({property: 'fm'}))
-  .pipe(marked())
+  .pipe(markdown())
   .pipe(accumulate('index.html', {
     debounce: true,
     sort: (x, y) => y.fm.date[0].valueOf() - x.fm.date[0].valueOf(),
@@ -55,7 +55,7 @@ asset('source/events/**/*.md')
 asset('source/events/**/*.md')
   .watch('source/**/*.{md,njk}')
   .pipe(frontMatter({property: 'fm'}))
-  .pipe(marked())
+  .pipe(markdown())
   .pipe(branch.obj(src => [
     src
       .pipe(accumulate('events.html', {
@@ -71,7 +71,7 @@ asset('source/events/**/*.md')
 asset('source/news/**/*.md')
   .watch('source/**/*.{md,njk}')
   .pipe(frontMatter({property: 'fm'}))
-  .pipe(marked())
+  .pipe(markdown())
   .pipe(branch.obj(src => [
     src
       .pipe(accumulate('news.html', {
@@ -110,7 +110,7 @@ const jobboardSort = (x, y) => getClassWeight(y) - getClassWeight(x) || postedAt
 asset('source/jobs/**/*.md')
   .watch('source/**/*.{md,njk}')
   .pipe(frontMatter({property: 'fm'}))
-  .pipe(marked())
+  .pipe(markdown())
   .pipe(branch.obj(src => [
     src
       .pipe(accumulate('jobboard.html', {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "bulbo": "^6.13.0",
     "gulp-front-matter": "^1.3.0",
-    "gulp-marked": "^1.0.0",
+    "gulp-markdown": "^2.0.1",
     "gulp-nunjucks": "^2.3.0",
     "layout-wrapper": "^1.1.1",
     "nunjucks": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,18 @@ abbrev@1:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
+ansi-cyan@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-cyan/-/ansi-cyan-0.1.1.tgz#538ae528af8982f28ae30d86f2f17456d2609873"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-red@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-red/-/ansi-red-0.1.1.tgz#8c638f9d1080800a353c9c28c8a81ca4705d946c"
+  dependencies:
+    ansi-wrap "0.1.0"
+
 ansi-regex@^0.2.0, ansi-regex@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-0.2.1.tgz#0d8e946967a3d8143f93e24e298525fc1b2235f9"
@@ -25,6 +37,10 @@ ansi-styles@^1.1.0:
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+
+ansi-wrap@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
 
 anymatch@^1.3.0:
   version "1.3.0"
@@ -50,6 +66,13 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+arr-diff@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-1.1.0.tgz#687c32758163588fef7de7b36fabe495eb1a399a"
+  dependencies:
+    arr-flatten "^1.0.1"
+    array-slice "^0.2.3"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -60,6 +83,10 @@ arr-flatten@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.1.tgz#e5ffe54d45e19f32f216e91eb99c8ce892bb604b"
 
+arr-union@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-2.1.0.tgz#20f9eab5ec70f5c7d215b1077b1c39161d292c7d"
+
 array-differ@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-1.0.0.tgz#eff52e3758249d33be402b8bb8e564bb2b5d4031"
@@ -67,6 +94,10 @@ array-differ@^1.0.0:
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
+
+array-slice@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/array-slice/-/array-slice-0.2.3.tgz#dd3cfb80ed7973a75117cdac69b0b99ec86186f5"
 
 array-uniq@^1.0.2:
   version "1.0.3"
@@ -475,6 +506,12 @@ expand-tilde@^1.2.1, expand-tilde@^1.2.2:
   dependencies:
     os-homedir "^1.0.1"
 
+extend-shallow@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-1.1.4.tgz#19d6bf94dfc09d76ba711f39b872d21ff4dd9071"
+  dependencies:
+    kind-of "^1.1.0"
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -746,6 +783,14 @@ gulp-front-matter@^1.3.0:
     readable-stream "^2.0.3"
     tryit "^1.0.1"
     vinyl-bufferstream "^1.0.1"
+
+gulp-markdown@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/gulp-markdown/-/gulp-markdown-2.0.1.tgz#45d9d50ccfd1ff11349d608d74a2fc41450f4650"
+  dependencies:
+    marked "^0.3.9"
+    plugin-error "^0.1.2"
+    through2 "^2.0.0"
 
 gulp-marked@^1.0.0:
   version "1.0.0"
@@ -1133,6 +1178,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
+kind-of@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-1.1.0.tgz#140a3d2d41a36d2efcfa9377b62c24f8495a5c44"
+
 kind-of@^3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.0.4.tgz#7b8ecf18a4e17f8269d73b501c9f232c96887a74"
@@ -1408,6 +1457,10 @@ map-cache@^0.2.0:
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+
+marked@^0.3.9:
+  version "0.3.12"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.12.tgz#7cf25ff2252632f3fe2406bde258e94eee927519"
 
 marked@~0.3.2:
   version "0.3.6"
@@ -1738,6 +1791,16 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+plugin-error@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-0.1.2.tgz#3b9bb3335ccf00f425e07437e19276967da47ace"
+  dependencies:
+    ansi-cyan "^0.1.1"
+    ansi-red "^0.1.1"
+    arr-diff "^1.0.1"
+    arr-union "^2.0.1"
+    extend-shallow "^1.1.2"
 
 preserve@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
See https://github.com/simbo/gulp-marked/issues/9

---
close #257 