### PR TITLE
イベントを作るボタン

### DIFF
--- a/source/layout/event-index.njk
+++ b/source/layout/event-index.njk
@@ -1,6 +1,7 @@
 {% extends layoutDir + '/default.njk' %}
 
 {% block main %}
+  <button type="submit" style="float: right;" onclick="window.open('https://github.com/nodejsjp/nodejsjp.github.com/new/source?path=source/events/2018&value=hello&filename=MM-DD-eventname.md&value=---%0Aname%3A%20%3C%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E5%90%8D%20%E4%BE%8B%3A%20Node%E5%AD%A6%E5%9C%92%2030%E6%99%82%E9%99%90%E7%9B%AE%3E%0Adate%3A%0A%20%20-%20%3CYYYY-MM-DD%3E%0Avenue%3A%0A%20%20-%20%3C%E4%BC%9A%E5%A0%B4%E5%90%8D%20%E4%BE%8B%3A%20%E3%82%B0%E3%83%A9%E3%83%B3%E3%82%B5%E3%82%A6%E3%82%B9%E3%82%BF%E3%83%AF%E3%83%BC%2041F%20%E3%82%A2%E3%82%AB%E3%83%87%E3%83%9F%E3%83%BC%E3%83%9B%E3%83%BC%E3%83%AB%3E%0Aticket%3A%0A%20%20-%20name%3A%20connpass%E3%82%88%E3%82%8A%E7%99%BB%E9%8C%B2%E3%81%97%E3%81%A6%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84%E3%80%82%0A%20%20%20%20url%3A%20%3Cconnpass%20%E3%81%AE%20URL%3E%0A---%0A%0A%3C!--%20%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E6%A6%82%E8%A6%81%E3%82%92%E8%A8%98%E8%BF%B0%20(%E3%83%9E%E3%83%BC%E3%82%AF%E3%83%80%E3%82%A6%E3%83%B3)%20--%3E%0A%0A%23%23%20%E5%8F%82%E5%8A%A0%E8%A6%81%E9%A0%85%0A%0A%3C!--%20%E8%A6%81%E9%A0%85%E3%82%92%E8%A8%98%E8%BF%B0%20(%E3%83%9E%E3%83%BC%E3%82%AF%E3%83%80%E3%82%A6%E3%83%B3)%20--%3E%0A%0A%23%23%20%E3%82%BF%E3%82%A4%E3%83%A0%E3%83%86%E3%83%BC%E3%83%96%E3%83%AB%0A%0A%3C!--%20%E3%82%BF%E3%82%A4%E3%83%A0%E3%83%86%E3%83%BC%E3%83%96%E3%83%AB%E3%82%92%E8%A8%98%E8%BF%B0%20(%E3%83%9E%E3%83%BC%E3%82%AF%E3%83%80%E3%82%A6%E3%83%B3)%20--%3E');">+</button>
   <h1>イベント情報</h1>
 
   {% for event in file.files %}


### PR DESCRIPTION
- イベント一覧ページの右上にイベントを作るボタンを設置しました。
- <a href="https://github.com/nodejsjp/nodejsjp.github.com/new/source?path=source/events/2018&value=hello&filename=MM-DD-eventname.md&value=---name%3A%20<イベント名%20例%3A%20Node学園%2030時限目>date%3A%20%20-%20<YYYY-MM-DD>venue%3A%20%20-%20<会場名%20例%3A%20グランサウスタワー%2041F%20アカデミーホール>ticket%3A%20%20-%20name%3A%20connpassより登録してください。%20%20%20%20url%3A%20<connpass%20の%20URL>---<!--%20イベント概要を記述%20(マークダウン)%20-->%23%23%20参加要項<!--%20要項を記述%20(マークダウン)%20-->%23%23%20タイムテーブル<!--%20タイムテーブルを記述%20(マークダウン)%20-->">このページ</a>にリンクされて、テンプレートが入った状態で、github のファイル作成画面に遷移します。

<img width="1009" alt="2018-04-27 15 46 00" src="https://user-images.githubusercontent.com/613956/39348624-d73bf0d6-4a32-11e8-8244-7a49879e8092.png">

---
close #239 